### PR TITLE
Add option to only show certain engines

### DIFF
--- a/src/chrome/content/contextsearch.js
+++ b/src/chrome/content/contextsearch.js
@@ -45,6 +45,7 @@ var contextsearch =
   , "extensions.contextsearch.hideStandardContextItem"
   , "extensions.contextsearch.quoteStringsWithSpaces"
   , "extensions.contextsearch.separatorItems"
+  , "extensions.contextsearch.showOnly"
   , "browser.tabs.loadInBackground"
   ]
   
@@ -255,13 +256,18 @@ var contextsearch =
     
     var popup = contextsearch.popup;
     var engines = contextsearch.searchService.getVisibleEngines({ });
-        
+    var showOnly = contextsearch.prefsMap["extensions.contextsearch.showOnly"];
+    if(showOnly)
+        showOnly = showOnly.split(',');
+    
     // clear menu
     while (popup.firstChild) {
       popup.removeChild(popup.firstChild);
     }
   
     for (var i = engines.length - 1; i >= 0; --i) {
+      if (showOnly.length && showOnly.indexOf(engines[i].name) == -1) continue;
+
       var menuitem = document.createElementNS(kXULNS, "menuitem");
       menuitem.setAttribute("label", engines[i].name);
       menuitem.setAttribute("id", engines[i].name);

--- a/src/defaults/preferences/contextsearch.js
+++ b/src/defaults/preferences/contextsearch.js
@@ -2,3 +2,4 @@ pref("extensions.contextsearch.clickMenuToSearch",false);
 pref("extensions.contextsearch.hideStandardContextItem",true);
 pref("extensions.contextsearch.quoteStringsWithSpaces",false);
 pref("extensions.contextsearch.separatorItems","");
+pref("extensions.contextsearch.showOnly","");


### PR DESCRIPTION
Added option `extensions.contextsearch.showOnly`, comma separated list of search engine names to show in the context menu. Search engines which are not included in that pref are hidden.
If pref is empty (default) then all engines are shown.
